### PR TITLE
Add simple main menu

### DIFF
--- a/MainMenu.gd
+++ b/MainMenu.gd
@@ -1,0 +1,23 @@
+extends Control
+
+
+func _ready() -> void:
+	$ButtonList/StartButton.pressed.connect(_onStartPressed)
+	$ButtonList/SettingsButton.pressed.connect(_onSettingsPressed)
+	$ButtonList/QuitButton.pressed.connect(_onQuitPressed)
+	$ButtonList/StartButton.grab_focus()
+
+
+func _onStartPressed():
+	 # TODO consider changing 'main.tscn's name to something more specific, like 'game' or 'level'?
+	get_tree().change_scene_to_file('res://main.tscn')
+
+
+func _onSettingsPressed():
+	# TODO placeholder because we don't have a settings system implemented yet, but once we do, I
+	# think we should make a separate scene for the settings menu & instantiate it here
+	pass
+
+
+func _onQuitPressed():
+	get_tree().quit()

--- a/MainMenu.tscn
+++ b/MainMenu.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=4 format=3 uid="uid://dphx8hlqf51ak"]
+
+[ext_resource type="Script" path="res://MainMenu.gd" id="1_cgyac"]
+[ext_resource type="Texture2D" uid="uid://cty7x4ry8qyhk" path="res://Sprites/tile_0108.png" id="2_k5unj"]
+
+[sub_resource type="LabelSettings" id="LabelSettings_wamif"]
+font_size = 120
+outline_size = 15
+outline_color = Color(0, 0, 0, 1)
+
+[node name="Menu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_cgyac")
+
+[node name="NinePatchRect" type="NinePatchRect" parent="."]
+layout_mode = 0
+offset_right = 1152.0
+offset_bottom = 648.0
+texture = ExtResource("2_k5unj")
+
+[node name="Label" type="Label" parent="NinePatchRect"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -202.0
+offset_top = -236.0
+offset_right = 202.0
+offset_bottom = -71.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "TITLE T"
+label_settings = SubResource("LabelSettings_wamif")
+
+[node name="ButtonList" type="VBoxContainer" parent="."]
+layout_mode = 0
+offset_left = 51.0
+offset_top = 503.0
+offset_right = 246.0
+offset_bottom = 604.0
+
+[node name="StartButton" type="Button" parent="ButtonList"]
+layout_mode = 2
+text = "Start"
+
+[node name="SettingsButton" type="Button" parent="ButtonList"]
+layout_mode = 2
+text = "Settings"
+
+[node name="QuitButton" type="Button" parent="ButtonList"]
+layout_mode = 2
+text = "Quit"

--- a/Player.gd
+++ b/Player.gd
@@ -33,7 +33,8 @@ func changeHealth(change: float):
 	%HealthBar.value += change
 #	Game over -> currently reset to start
 	if %HealthBar.value <= %HealthBar.min_value:
-		get_tree().reload_current_scene()
+		#get_tree().reload_current_scene() # NOTE keeping this here since surely we'll wanna toggle on/off during development
+		get_tree().change_scene_to_file('res://MainMenu.tscn')
 
 func changeXP(change: int):
 	%XPBar.value += change

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="TD2D"
-run/main_scene="res://main.tscn"
+run/main_scene="res://MainMenu.tscn"
 config/features=PackedStringArray("4.2", "Forward Plus")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
Added a simple main menu. Currently has 3 buttons, only 2 actually do something:

- Start: Goes to `main.tscn`
- Settings: Placeholder, since we don't have a settings system or menu setup yet
- Quit: Closes the game (no clue what happens if you do this on web, so....)

Ticket mentioned name entry, that isn't included here. Can be added later under this ticket or a new one

Uses default UI behavior, so the buttons can be clicked or navigated with arrows/tab & space/enter. Haven't tested gamepad